### PR TITLE
Feat/nullable as proc params

### DIFF
--- a/internal/argtype.go
+++ b/internal/argtype.go
@@ -159,6 +159,9 @@ type ArgType struct {
 	// ShortNameTypeMap is the collection of Go style short names for types, mainly
 	// used for use with declaring a func receiver on a type.
 	ShortNameTypeMap map[string]string `arg:"-"`
+
+	// NullableProcParams toggle nullable types for stored procedure parameters.
+	NullableProcParams bool `arg:"--nullable-proc-params"`
 }
 
 // NewDefaultArgs returns the default arguments.

--- a/internal/loader.go
+++ b/internal/loader.go
@@ -445,7 +445,7 @@ func (tl TypeLoader) LoadProcParams(args *ArgType, procTpl *Proc) error {
 			Name: fmt.Sprintf("v%d", i),
 		}
 
-		_, _, paramTpl.Type = tl.ParseType(args, strings.TrimSpace(p.ParamType), true)
+		_, _, paramTpl.Type = tl.ParseType(args, strings.TrimSpace(p.ParamType), args.NullableProcParams)
 
 		// add to proc params
 		if procTpl.ProcParams != "" {

--- a/internal/loader.go
+++ b/internal/loader.go
@@ -445,8 +445,7 @@ func (tl TypeLoader) LoadProcParams(args *ArgType, procTpl *Proc) error {
 			Name: fmt.Sprintf("v%d", i),
 		}
 
-		// TODO: fix this so that nullable types can be used as parameters
-		_, _, paramTpl.Type = tl.ParseType(args, strings.TrimSpace(p.ParamType), false)
+		_, _, paramTpl.Type = tl.ParseType(args, strings.TrimSpace(p.ParamType), true)
 
 		// add to proc params
 		if procTpl.ProcParams != "" {


### PR DESCRIPTION
Apparently all of the DBs supported by gendal support nullable parameters, hence using nullable parameters in stored procedures allow for broader effectivness.

I still prefer to make it a user choice and using a cli argument because some user don't want to have nullable variables everywhere, hence `--nullable-proc-params`